### PR TITLE
[fix/update]ステート名の変更と建設状態を時間経過で遷移するようにした

### DIFF
--- a/Assets/WorkSpace/Facility/ConstructionState.cs
+++ b/Assets/WorkSpace/Facility/ConstructionState.cs
@@ -6,33 +6,53 @@ public class ConstructionState : MonoBehaviour
 {
     [SerializeField, Tooltip("現在の建設状態")] FacilityState _currentState = FacilityState.NotInstalled;
 
+    // このオブジェクトの施設の種類(データを取得してくる)
+    Facility _facilityType;
+    // 施設の建設に必要な施工時間(データを取得してくる)
+    float _workTime = 0;
+    // 建設経過時間
+    float _elapsedTime = 0;
+
     void Start()
     {
-        
+
     }
 
     void Update()
     {
-        if (_currentState == FacilityState.Construction)
+        if (_currentState == FacilityState.Constructing)
         {
-            // ステートを変移させていく
-
+            _elapsedTime = Time.deltaTime;
+            if (_elapsedTime > _workTime)
+            {
+                _currentState = FacilityState.Working;
+            }
         }
     }
 
-    // 建設開始　をBuildingManagerで呼ぶ
+    /// <summary>
+    /// 施設の建設状態を建設中に変える
+    /// BuildingManagerで呼ぶ
+    /// </summary>
     public void StartConstruction()
     {
-        _currentState = FacilityState.Construction;
+        _currentState = FacilityState.Constructing;
     }
 
+    /// <summary>
+    /// 施設の建設状態を管理するenum
+    /// </summary>
     public enum FacilityState
     {
         NotInstalled,   // 未設置
-        Construction,   // 建築中
-        InOperation,    // 稼働中
+        Constructing,   // 建築中
+        Working,        // 稼働中
     }
 
+    /// <summary>
+    /// 現在の施設の建設状態を取得するための関数
+    /// </summary>
+    /// <returns></returns>
     public FacilityState GetFacilityState()
     {
         return _currentState;

--- a/Assets/WorkSpace/Facility/MineFunction.cs
+++ b/Assets/WorkSpace/Facility/MineFunction.cs
@@ -27,7 +27,7 @@ public class MineFunction : MonoBehaviour, IPointerClickHandler
     void Update()
     {
         // 建設状態が稼働中になったら
-        if (_constructionState.GetFacilityState() == ConstructionState.FacilityState.InOperation)
+        if (_constructionState.GetFacilityState() == ConstructionState.FacilityState.Working)
         {
             _currentTime += Time.deltaTime;
             if (_currentTime > _span)

--- a/Assets/WorkSpace/Facility/SoldierTrainingSchoolFunction.cs
+++ b/Assets/WorkSpace/Facility/SoldierTrainingSchoolFunction.cs
@@ -31,13 +31,13 @@ public class SoldierTrainingSchoolFunction : MonoBehaviour, IPointerClickHandler
     public void OnPointerClick(PointerEventData eventData)
     {
         // 建設状態が稼働中になったら
-        if (_constructionState.GetFacilityState() == ConstructionState.FacilityState.InOperation)
+        if (_constructionState.GetFacilityState() == ConstructionState.FacilityState.Working)
         {
             if (_dataManager.Gold > _price)
             {
                 //if (兵士の作成上限数に達していなければ)
                 {
-                    _dataManager.ChangeGold(_price);
+                    _dataManager.ChangeGold(-_price);
                     Instantiate(_soldierPrefab, this.transform.position, Quaternion.identity);
 
                     _dataManager.ChangeResource(_addResource);


### PR DESCRIPTION
やったこと
・建設状態を管理するenumの名前を変更
・建設状態を時間経過で稼働中に遷移するように更新(施工時間は後で取得予定)
・SoldierTrainingSchoolFunctionのゴールド消費の処理が間違っていたので修正
・summaryの追加