### PR TITLE
[add/update]フォルダの追加、一部施設をアセットに置き換え

### DIFF
--- a/Assets/WorkSpace/Facility/Prefabs.meta
+++ b/Assets/WorkSpace/Facility/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: faa4095eea7b4e449817abbbc9063466
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/WorkSpace/Facility/Prefabs/Parts.meta
+++ b/Assets/WorkSpace/Facility/Prefabs/Parts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 227f70911cb94ba4e9d46622f0800a89
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
やったこと
・施設プレハブ用のフォルダの追加
Packageで共有するものについて
・兵士育成所以外の施設をアセットに置き換え(2パターン作りましたが使いやすい方で)
→・プレハブを作っただけなのでボタンで生成されるものはテスト用のままです。
　・テスト用プレハブの設置範囲に合わせて作ったのでサイズが小さいです。
レビューして欲しいところ(Discordでも大丈夫です)
・サイズ感見ていただきたいです。(設置判定のサイズは統一してます)
・Colliderの種類がMeshか全体をまとめたBoxの方がいいかわからなかったので今の状態で大丈夫か確認して欲しいです。